### PR TITLE
feat: 统一备份管理界面样式与任务创建对话框

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -965,6 +965,78 @@ body {
   background: #17a2b8;
 }
 
+/* 备份管理样式 */
+.backup-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px;
+  border-bottom: 1px solid #e1e5e9;
+  transition: background-color 0.2s;
+}
+
+.backup-item:last-child {
+  border-bottom: none;
+}
+
+.backup-item:hover {
+  background-color: #f8f9fa;
+}
+
+.backup-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.backup-date {
+  font-weight: 600;
+  color: #333;
+  font-size: 14px;
+}
+
+.backup-details {
+  font-size: 12px;
+  color: #6c757d;
+}
+
+.backup-type {
+  padding: 4px 8px;
+  border-radius: 4px;
+  color: white;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.backup-type.manual {
+  background-color: #3498db;
+}
+
+.backup-type.auto {
+  background-color: #9b59b6;
+}
+
+.backup-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.backup-actions .btn-save,
+.backup-actions .btn-delete {
+  padding: 8px 16px;
+  font-size: 12px;
+  min-width: 60px;
+}
+
+.no-backups {
+  text-align: center;
+  padding: 40px 20px;
+  color: #6c757d;
+  font-style: italic;
+}
+
 /* 按钮样式 */
 .btn-primary {
   padding: 8px 20px;

--- a/styles.css
+++ b/styles.css
@@ -718,27 +718,7 @@ body {
     border-bottom: 1px solid #ecf0f1;
 }
 
-.modal-header h2 {
-    color: #2c3e50;
-    font-size: 20px;
-}
-
-.close {
-    color: #aaa;
-    font-size: 28px;
-    font-weight: bold;
-    cursor: pointer;
-    transition: color 0.3s ease;
-}
-
-.close:hover {
-    color: #e74c3c;
-}
-
-/* 表单样式 */
-#taskForm {
-    padding: 30px;
-}
+/* 备份管理样式已移至 src/style.css 中统一管理 */
 
 .form-group {
     margin-bottom: 20px;
@@ -769,40 +749,7 @@ body {
     border-color: #3498db;
 }
 
-.form-actions {
-    display: flex;
-    gap: 15px;
-    justify-content: flex-end;
-    margin-top: 30px;
-}
-
-.btn-cancel,
-.btn-submit {
-    padding: 12px 24px;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    font-weight: 600;
-    transition: all 0.3s ease;
-}
-
-.btn-cancel {
-    background: #95a5a6;
-    color: white;
-}
-
-.btn-cancel:hover {
-    background: #7f8c8d;
-}
-
-.btn-submit {
-    background: #27ae60;
-    color: white;
-}
-
-.btn-submit:hover {
-    background: #229954;
-}
+/* 按钮样式已移至 src/style.css 中统一管理 */
 
 /* 动画 */
 @keyframes fadeIn {
@@ -918,6 +865,8 @@ body {
     padding: 40px;
     font-style: italic;
 }
+
+/* 备份管理样式已移至 src/style.css 中统一管理 */
 
 /* 响应式设计 */
 @media (max-width: 768px) {


### PR DESCRIPTION
- 将备份管理模态框标题从h2改为h3，与任务模态框保持一致
- 更新关闭按钮类名从.close改为.close-btn
- 统一表单容器结构，使用task-form类
- 更新按钮样式：恢复按钮使用btn-save，删除按钮使用btn-delete
- 将备份相关样式从styles.css移至src/style.css统一管理
- 删除重复和过时的样式定义，避免样式冲突
- 改进备份项视觉效果，增加悬停状态和更好的间距