### PR TITLE
Remove redundant fetch mock

### DIFF
--- a/src/test/App.test.js
+++ b/src/test/App.test.js
@@ -18,13 +18,6 @@ describe('App.vue', () => {
   let wrapper
 
   beforeEach(() => {
-    // 模拟fetch API
-    global.fetch = vi.fn(() =>
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(mockTasks)
-      })
-    )
 
     wrapper = mount(App)
   })


### PR DESCRIPTION
## Summary
- remove specific fetch mock from App.test
- keep using the global fetch mock from `src/test/setup.js`

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_6870dca7238c832db806a165cc53cfe0