### PR TITLE
Fix font size for bright backgrounds

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1175,9 +1175,9 @@ export default {
       
       // 计算亮度
       const brightness = (0.299 * r + 0.587 * g + 0.114 * b);
-      
+
       // 浅色背景稍微增大字体，深色背景保持正常
-      return brightness > 128 ? '0.9em' : '0.9em';
+      return brightness > 128 ? '1em' : '0.9em';
     },
     
     // 根据背景颜色获取文字阴影效果


### PR DESCRIPTION
## Summary
- adjust `getFontSize` in App.vue so bright backgrounds use a larger font size

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6870dca5f378832db41ebe8f35c8a81e