### PR TITLE
Implement centralized style management

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,49 @@
+# Style System
+
+This project uses a centralized style system to keep visual design consistent.
+
+## CSS Variables
+
+Common colors are declared in `src/styles/variables.css`. Use these variables instead of hard-coded color values.
+
+```css
+:root {
+  --primary-color: #3498db;
+  --primary-color-dark: #2980b9;
+  --success-color: #28a745;
+  --error-color: #dc3545;
+  --warning-color: #ffc107;
+  --info-color: #2196f3;
+  --text-color: #333;
+  --muted-color: #666;
+  --background-color: #f5f7fa;
+}
+```
+
+Import the variables in `src/main.js`:
+
+```javascript
+import './styles/variables.css'
+```
+
+## Style Service
+
+`src/services/styleService.js` provides helper functions for computing task styles. Components should call these methods instead of duplicating style logic.
+
+Example:
+
+```javascript
+import { styleService } from '../services/styleService'
+
+methods: {
+  getTaskStyle(task) {
+    return styleService.getTaskStyle(task)
+  }
+}
+```
+
+## Conventions
+
+- Prefer CSS variables for colors and common values.
+- Avoid inline styles when possible.
+- Use the style service for task-related style calculations.

--- a/src/App.vue
+++ b/src/App.vue
@@ -373,7 +373,7 @@ export default {
 }
 
 .add-task-btn {
-  background: #4CAF50;
+  background: var(--success-color);
   border: none;
   color: white;
   padding: 10px 20px;
@@ -384,7 +384,7 @@ export default {
 }
 
 .add-task-btn:hover {
-  background: #45a049;
+  background: var(--success-color);
   transform: translateY(-1px);
 }
 
@@ -500,19 +500,19 @@ export default {
 }
 
 .message-modal-success .message-icon {
-  color: #4CAF50;
+  color: var(--success-color);
 }
 
 .message-modal-error .message-icon {
-  color: #f44336;
+  color: var(--error-color);
 }
 
 .message-modal-confirm .message-icon {
-  color: #ff9800;
+  color: var(--warning-color);
 }
 
 .message-modal-info .message-icon {
-  color: #2196F3;
+  color: var(--info-color);
 }
 
 /* 按钮样式 */
@@ -547,7 +547,7 @@ export default {
 }
 
 .btn-primary {
-  background: #007bff;
+  background: var(--primary-color);
   border: none;
   color: white;
   padding: 10px 20px;
@@ -558,32 +558,32 @@ export default {
 }
 
 .btn-primary:hover {
-  background: #0056b3;
+  background: var(--primary-color-dark);
 }
 
 .btn-success {
-  background: #28a745;
+  background: var(--success-color);
 }
 
 .btn-success:hover {
-  background: #1e7e34;
+  background: var(--success-color);
 }
 
 .btn-error {
-  background: #dc3545;
+  background: var(--error-color);
 }
 
 .btn-error:hover {
-  background: #c82333;
+  background: var(--error-color);
 }
 
 .btn-confirm {
-  background: #ffc107;
+  background: var(--warning-color);
   color: #212529;
 }
 
 .btn-confirm:hover {
-  background: #e0a800;
+  background: var(--warning-color);
 }
 
 /* 响应式设计 */

--- a/src/components/CalendarView.vue
+++ b/src/components/CalendarView.vue
@@ -114,6 +114,7 @@
 import { useCalendarStore } from '../store/modules/calendarStore'
 import { useTaskStore } from '../store/modules/taskStore'
 import { dateService } from '../services/dateService'
+import { styleService } from '../services/styleService'
 
 export default {
   name: 'CalendarView',
@@ -174,77 +175,7 @@ export default {
       return dateService.isToday(date)
     },
     getTaskStyle(task) {
-      const backgroundColor = task.tagColor || '#3498db'
-      return {
-        backgroundColor,
-        color: this.getTextColor(backgroundColor),
-        fontWeight: this.getFontWeight(backgroundColor),
-        fontSize: this.getFontSize(backgroundColor),
-        textShadow: this.getTextShadow(backgroundColor)
-      }
-    },
-    // 根据背景颜色计算合适的文字颜色 - 始终返回白色字体
-    getTextColor(backgroundColor) {
-      // 在任何情况下都返回白色字体
-      return '#ffffff'
-    },
-    
-    // 根据背景颜色获取合适的字体粗细
-    getFontWeight(backgroundColor) {
-      if (!backgroundColor) return 'normal'
-      
-      // 移除 # 号并确保是6位十六进制
-      let hex = backgroundColor.replace('#', '')
-      if (hex.length === 3) {
-        hex = hex.split('').map(char => char + char).join('')
-      }
-      
-      if (hex.length !== 6 || !/^[0-9A-Fa-f]+$/.test(hex)) {
-        return 'normal'
-      }
-      
-      // 转换为 RGB
-      const r = parseInt(hex.substr(0, 2), 16)
-      const g = parseInt(hex.substr(2, 2), 16)
-      const b = parseInt(hex.substr(4, 2), 16)
-      
-      // 计算亮度
-      const brightness = (0.299 * r + 0.587 * g + 0.114 * b)
-      
-      // 浅色背景使用更粗的字体，深色背景使用较细的字体
-      return brightness > 128 ? '900' : '100'
-    },
-    
-    // 根据背景颜色获取字体大小调整 - 统一字体大小
-    getFontSize(backgroundColor) {
-      // 现在所有字体都是白色，统一使用标准字体大小
-      return '1em'
-    },
-    
-    // 根据背景颜色获取文字阴影效果
-    getTextShadow(backgroundColor) {
-      if (!backgroundColor) return 'none'
-      
-      // 移除 # 号并确保是6位十六进制
-      let hex = backgroundColor.replace('#', '')
-      if (hex.length === 3) {
-        hex = hex.split('').map(char => char + char).join('')
-      }
-      
-      if (hex.length !== 6 || !/^[0-9A-Fa-f]+$/.test(hex)) {
-        return 'none'
-      }
-      
-      // 转换为 RGB
-      const r = parseInt(hex.substr(0, 2), 16)
-      const g = parseInt(hex.substr(2, 2), 16)
-      const b = parseInt(hex.substr(4, 2), 16)
-      
-      // 计算亮度
-      const brightness = (0.299 * r + 0.587 * g + 0.114 * b)
-      
-      // 浅色背景给黑字添加轻微阴影增强视觉效果
-      return brightness > 128 ? '0 0 1px rgba(0,0,0,0.3)' : 'none'
+      return styleService.getTaskStyle(task)
     }
   },
   mounted() {

--- a/src/components/TaskList.vue
+++ b/src/components/TaskList.vue
@@ -137,6 +137,7 @@
 import { useTaskStore } from '../store/modules/taskStore'
 import { useCalendarStore } from '../store/modules/calendarStore'
 import { dateService } from '../services/dateService'
+import { styleService } from '../services/styleService'
 
 export default {
   name: 'TaskList',
@@ -297,17 +298,7 @@ export default {
     },
     
     getTaskTagStyle(task) {
-      const backgroundColor = task.tagColor || '#3498db'
-      return {
-        backgroundColor,
-        color: this.getTextColor(backgroundColor)
-      }
-    },
-    
-    // 智能文字颜色计算 - 始终返回白色字体
-    getTextColor(backgroundColor) {
-      // 在任何情况下都返回白色字体
-      return '#ffffff'
+      return styleService.getTaskTagStyle(task)
     }
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import { createApp } from 'vue'
+import './styles/variables.css'
 import './style.css'
 import App from './App.vue'
 import { pinia } from './store'

--- a/src/services/styleService.js
+++ b/src/services/styleService.js
@@ -1,0 +1,61 @@
+export const styleService = {
+  getTaskStyle(task) {
+    const backgroundColor = task.tagColor || 'var(--primary-color)'
+    return {
+      backgroundColor,
+      color: this.getTextColor(backgroundColor),
+      fontWeight: this.getFontWeight(backgroundColor),
+      fontSize: this.getFontSize(backgroundColor),
+      textShadow: this.getTextShadow(backgroundColor)
+    }
+  },
+
+  getTaskTagStyle(task) {
+    const backgroundColor = task.tagColor || 'var(--primary-color)'
+    return {
+      backgroundColor,
+      color: this.getTextColor(backgroundColor)
+    }
+  },
+
+  // always return white text color
+  getTextColor() {
+    return '#ffffff'
+  },
+
+  getFontWeight(backgroundColor) {
+    if (!backgroundColor) return 'normal'
+    let hex = backgroundColor.replace('#', '')
+    if (hex.length === 3) {
+      hex = hex.split('').map(c => c + c).join('')
+    }
+    if (hex.length !== 6 || !/^[0-9A-Fa-f]+$/.test(hex)) {
+      return 'normal'
+    }
+    const r = parseInt(hex.substr(0, 2), 16)
+    const g = parseInt(hex.substr(2, 2), 16)
+    const b = parseInt(hex.substr(4, 2), 16)
+    const brightness = 0.299 * r + 0.587 * g + 0.114 * b
+    return brightness > 128 ? '900' : '100'
+  },
+
+  getFontSize() {
+    return '1em'
+  },
+
+  getTextShadow(backgroundColor) {
+    if (!backgroundColor) return 'none'
+    let hex = backgroundColor.replace('#', '')
+    if (hex.length === 3) {
+      hex = hex.split('').map(c => c + c).join('')
+    }
+    if (hex.length !== 6 || !/^[0-9A-Fa-f]+$/.test(hex)) {
+      return 'none'
+    }
+    const r = parseInt(hex.substr(0, 2), 16)
+    const g = parseInt(hex.substr(2, 2), 16)
+    const b = parseInt(hex.substr(4, 2), 16)
+    const brightness = 0.299 * r + 0.587 * g + 0.114 * b
+    return brightness > 128 ? '0 0 1px rgba(0,0,0,0.3)' : 'none'
+  }
+}

--- a/src/style.css
+++ b/src/style.css
@@ -7,8 +7,8 @@
 
 body {
     font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background-color: #f5f7fa;
-    color: #333;
+    background-color: var(--background-color);
+    color: var(--text-color);
     line-height: 1.6;
 }
 
@@ -31,7 +31,7 @@ body {
 }
 
 .header h1 {
-    color: #2c3e50;
+    color: var(--text-color);
     font-size: 24px;
     font-weight: 600;
 }
@@ -43,7 +43,7 @@ body {
 }
 
 .nav-btn {
-    background: #3498db;
+    background: var(--primary-color);
     color: white;
     border: none;
     width: 40px;
@@ -55,7 +55,7 @@ body {
 }
 
 .nav-btn:hover {
-    background: #2980b9;
+    background: var(--primary-color-dark);
     transform: scale(1.1);
 }
 
@@ -79,7 +79,7 @@ body {
 }
 
 .file-btn {
-    background: #34495e;
+    background: var(--primary-color-dark);
     color: white;
     border: none;
     padding: 10px 16px;
@@ -91,7 +91,7 @@ body {
 }
 
 .file-btn:hover {
-    background: #2c3e50;
+    background: var(--primary-color);
     transform: translateY(-1px);
 }
 
@@ -112,12 +112,12 @@ body {
 }
 
 .view-btn.active {
-    background: #3498db;
+    background: var(--primary-color);
     color: white;
 }
 
 .add-task-btn {
-    background: #27ae60;
+    background: var(--success-color);
     color: white;
     border: none;
     padding: 12px 24px;
@@ -128,7 +128,7 @@ body {
 }
 
 .add-task-btn:hover {
-    background: #229954;
+    background: var(--success-color);
     transform: translateY(-2px);
 }
 
@@ -139,7 +139,7 @@ body {
 }
 
 .backup-btn {
-    background: #9b59b6;
+    background: var(--info-color);
     color: white;
     border: none;
     padding: 8px 16px;
@@ -151,12 +151,12 @@ body {
 }
 
 .backup-btn:hover {
-    background: #8e44ad;
+    background: var(--info-color);
     transform: translateY(-1px);
 }
 
 .export-btn, .import-btn {
-    background: #27ae60;
+    background: var(--success-color);
     color: white;
     border: none;
     padding: 8px 16px;
@@ -167,15 +167,15 @@ body {
 }
 
 .export-btn:hover {
-    background: #229954;
+    background: var(--success-color);
 }
 
 .import-btn {
-    background: #e67e22;
+    background: var(--warning-color);
 }
 
 .import-btn:hover {
-    background: #d35400;
+    background: var(--warning-color);
 }
 
 /* 搜索栏样式 */
@@ -1020,21 +1020,21 @@ body {
 }
 
 .btn-success {
-  background: #28a745;
+  background: var(--success-color);
   color: white;
 }
 
 .btn-success:hover {
-  background: #218838;
+  background: var(--success-color);
 }
 
 .btn-error {
-  background: #dc3545;
+  background: var(--error-color);
   color: white;
 }
 
 .btn-error:hover {
-  background: #c82333;
+  background: var(--error-color);
 }
 
 .btn-confirm {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,0 +1,11 @@
+:root {
+  --primary-color: #3498db;
+  --primary-color-dark: #2980b9;
+  --success-color: #28a745;
+  --error-color: #dc3545;
+  --warning-color: #ffc107;
+  --info-color: #2196f3;
+  --text-color: #333;
+  --muted-color: #666;
+  --background-color: #f5f7fa;
+}


### PR DESCRIPTION
## Summary
- centralize task style calculations with `styleService`
- define CSS variables for core colors and import them globally
- refactor CalendarView and TaskList components to use the style service
- update styles to use the new variables
- document the style system in `STYLE_GUIDE.md`

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_6873290f66dc832dad6a90b0cc940a6e